### PR TITLE
Fixed generated plugin file incompatible with latest IDEA (#4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ intellij {
     version 'IC-2016.1'
     plugins = ['coverage']   //Bundled plugin dependencies
     pluginName 'org4idea'
+    updateSinceUntilBuild false
 
     publish {
         username jetbrains_username ?: ""


### PR DESCRIPTION
Set updateSinceUntilBuild to false (default true) so intellij gradle does not limit the plugin file to only the specified version.

Fixes  https://github.com/skuro/org4idea/issues/4
